### PR TITLE
dependencies add pedding

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "combo-url": "~0.2.0",
     "debug": "~1.0.4",
     "mime": "~1.2.11",
-    "urlproxy": "~0.1.0"
+    "urlproxy": "~0.1.0",
+    "pedding": "1.0.0"
   },
   "devDependencies": {
     "connect": "~2.14.4",


### PR DESCRIPTION
package 缺少 `pedding` 

```
var pedding = require('pedding');


$cd examples 
examples $node static-server

module.js:340
    throw err;
          ^
Error: Cannot find module 'pedding'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/nimojs/Downloads/connect-combo/index.js:7:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```